### PR TITLE
[MIG][14.0] base: delete_web_diagram_assets

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
@@ -83,6 +83,19 @@ def deduplicate_ir_properties(cr):
     )
 
 
+def delete_web_diagram_assets(cr):
+    # module web_diagram that is deleted in Odoo CE 14.0
+    # to need to delete web diagram assets in ir_ui_view
+    # which causes style conflict with module to_backend_theme
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_ui_view
+        WHERE key = 'web_diagram.assets_backend' OR key = 'web_diagram.qunit_suite';
+        """,
+    )
+
+
 @openupgrade.migrate(use_env=False)
 def migrate(cr, version):
     """
@@ -127,3 +140,4 @@ def migrate(cr, version):
         cr, "UPDATE res_partner SET lang = 'tl_PH' WHERE lang = 'fil_PH'"
     )
     deduplicate_ir_properties(cr)
+    delete_web_diagram_assets(cr)


### PR DESCRIPTION
Module `web_diagram` that is deleted in Odoo CE 14.0, to need to delete web diagram assets in `ir_ui_view` which causes style conflict with module `to_backend_theme`