### PR TITLE
[FIX][14.0] account: process account payment transfer

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -599,17 +599,7 @@ def fill_statement_lines_with_no_move(env):
             _logger.error("Failed for statement line with id %s: %s", st_line.id, e)
             raise
         deprecated_accounts.deprecated = True
-        to_write = {
-            "line_ids": [
-                (0, 0, line_vals)
-                for line_vals in st_line._prepare_move_line_default_vals(
-                    counterpart_account_id=False
-                )
-            ]
-        }
-        st_line.move_id.with_context(skip_account_move_synchronization=True).write(
-            to_write
-        )
+
     openupgrade.logged_query(
         env.cr,
         """

--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -791,17 +791,6 @@ def fill_account_payment_with_no_move(env):
             _logger.error("Failed for payment with id %s: %s", payment.id, e)
             raise
         deprecated_accounts.deprecated = True
-        to_write = {
-            "line_ids": [
-                (0, 0, line_vals)
-                for line_vals in payment._prepare_move_line_default_vals(
-                    write_off_line_vals=False
-                )
-            ]
-        }
-        payment.move_id.with_context(skip_account_move_synchronization=True).write(
-            to_write
-        )
 
 
 def try_delete_noupdate_records(env):

--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -669,6 +669,45 @@ def fill_account_journal_payment_credit_debit_account_id(env):
         )
 
 
+def create_new_counterpar_account_payment_transfer(env):
+    # Create new counterpart payment with account payment transfer
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO account_payment (move_id, is_internal_transfer, partner_type,
+            payment_type,
+            amount, currency_id,
+            destination_account_id, partner_id, journal_id,
+            create_uid, create_date, write_uid, write_date)
+        SELECT move.id, true, ap.partner_type,
+            CASE
+            WHEN journal.id = ap.destination_journal_id THEN 'inbound' ELSE 'outbound'
+            END,
+            ap.amount, ap.currency_id,
+            ap.destination_account_id, ap.partner_id, move.journal_id,
+            ap.create_uid, ap.create_date, ap.write_uid, ap.write_date
+        FROM account_payment ap
+        JOIN account_move move
+            ON (move.payment_id = ap.id AND move.id != ap.move_id)
+        JOIN account_journal journal ON journal.id = move.journal_id
+        WHERE ap.payment_type = 'transfer'
+        """,
+    )
+
+
+def map_account_payment_transfer(env):
+    # map payment_type from transfer to 'outbound'
+    # and set is_internal_transfer as true on account payment transfer
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_payment ap
+        SET is_internal_transfer = true, payment_type = 'outbound'
+        WHERE ap.payment_type = 'transfer'
+        """,
+    )
+
+
 def fill_account_payment_with_no_move(env):
     p_data = {}
     p_dates_by_company = {}
@@ -831,6 +870,8 @@ def migrate(env, version):
     fill_company_account_journal_suspense_account_id(env)
     fill_statement_lines_with_no_move(env)
     fill_account_journal_payment_credit_debit_account_id(env)
+    create_new_counterpar_account_payment_transfer(env)
+    map_account_payment_transfer(env)
     fill_account_payment_with_no_move(env)
     _delete_hooks(env)
     openupgrade.delete_record_translations(

--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -295,7 +295,8 @@ account      / account.payment          / payment_method_id (many2one)  : now a 
 # NOTHING TO DO
 
 account      / account.payment          / payment_type (selection)      : selection_keys is now '['inbound', 'outbound']' ('['inbound', 'outbound', 'transfer']')
-# TODO: transfer records should be changed to 'inbound' or 'outbound', but if we do that, we should remove two account move lines
+# DONE post-migration: mapped payment_type from 'transfer' to 'inbound'/'outbound' for account payment tranfer
+# created new counterpart payment with account payment transfer
 # (see https://github.com/odoo/odoo/commit/a30cfee04eaf48b581d2e327c1b56e115a1c751f)
 # DONE pre-migration: filled partner_id with journal_id.company_id.partner_id to detect transfers
 


### PR DESCRIPTION
Cherry-pick from https://github.com/OCA/OpenUpgrade/pull/3140 and https://github.com/OCA/OpenUpgrade/pull/3159

1. map payment_type from 'transfer' to 'inbound'/'outbound'
2. set is_internal_transfer as true on account payment transfer
3. create new counterpart payment with account payment transfer