### PR TITLE
[FIX][14.0] hr_holidays: missing Time Off Description

### DIFF
--- a/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/pre-migration.py
@@ -4,7 +4,9 @@
 from openupgradelib import openupgrade
 
 _column_copies = {
-    "hr_leave_type": [("validation_type", "allocation_validation_type", "varchar")]
+    "hr_leave_type": [("validation_type", "allocation_validation_type", "varchar")],
+    "hr_leave": [("name", "private_name", "varchar")],
+    "hr_leave_allocation": [("name", "private_name", "varchar")],
 }
 
 _field_renames = [

--- a/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/upgrade_analysis_work.txt
@@ -21,7 +21,11 @@ hr_holidays  / hr.leave                 / employee_id (many2one)        : now a 
 hr_holidays  / hr.leave                 / holiday_status_id (many2one)  : now a function
 hr_holidays  / hr.leave                 / manager_id (many2one)         : now a function
 hr_holidays  / hr.leave                 / mode_company_id (many2one)    : now a function
+# NOTHING TO DO
+
 hr_holidays  / hr.leave                 / name (char)                   : not stored anymore
+# DONE: pre-migration: rename name > private_name
+
 hr_holidays  / hr.leave                 / name (char)                   : now a function
 hr_holidays  / hr.leave                 / number_of_days (float)        : now a function
 hr_holidays  / hr.leave                 / request_unit_custom (boolean) : now a function
@@ -37,7 +41,11 @@ hr_holidays  / hr.leave.allocation      / interval_number (integer)     : now a 
 hr_holidays  / hr.leave.allocation      / interval_unit (selection)     : now a function
 hr_holidays  / hr.leave.allocation      / manager_id (many2one)         : now a function
 hr_holidays  / hr.leave.allocation      / mode_company_id (many2one)    : now a function
+# NOTHING TO DO
+
 hr_holidays  / hr.leave.allocation      / name (char)                   : not stored anymore
+# DONE: pre-migration: rename name > private_name
+
 hr_holidays  / hr.leave.allocation      / name (char)                   : now a function
 hr_holidays  / hr.leave.allocation      / number_of_days (float)        : now a function
 hr_holidays  / hr.leave.allocation      / number_per_interval (float)   : now a function


### PR DESCRIPTION
Steps:
1. Create a time off with description
2. Run migration
3. Missing Description

Solution: reanme field `name` to `private_name` on `hr_leave` to avoid missing Time Off Description