### PR TITLE
[FIX][14.0] account: correct payment's currency

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -158,6 +158,7 @@ def copy_fields(env):
                 ("journal_id", None, None),
                 ("name", None, None),
                 ("payment_date", None, None),
+                ("currency_id", None, None),
             ],
         },
     )
@@ -273,16 +274,6 @@ def add_move_id_field_account_bank_statement_line(env):
 
 
 def add_move_id_field_account_payment(env):
-    openupgrade.logged_query(
-        env.cr,
-        """
-        UPDATE account_payment ap
-        SET currency_id = COALESCE(aj.currency_id, rc.currency_id)
-        FROM account_journal aj
-        JOIN res_company rc ON aj.company_id = rc.id
-        WHERE ap.journal_id = aj.id
-        """,
-    )
     if not openupgrade.column_exists(env.cr, "account_payment", "move_id"):
         openupgrade.logged_query(
             env.cr,
@@ -315,7 +306,7 @@ def add_move_id_field_account_payment(env):
         UPDATE account_payment ap
         SET move_id = am.id
         FROM account_move am
-        WHERE am.payment_id = ap.id""",
+        WHERE ap.move_id IS NOT NULL AND am.payment_id = ap.id""",
     )
     # 2. try to match on payment move_name or payment_reference (if move_name empty)
     openupgrade.logged_query(
@@ -351,6 +342,17 @@ def add_move_id_field_account_payment(env):
         FROM account_payment ap
         WHERE am.id = ap.move_id
         """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move am
+        SET currency_id = ap.{}
+        FROM account_payment ap
+        WHERE am.id = ap.move_id
+        """.format(
+            openupgrade.get_legacy_name("currency_id"),
+        ),
     )
 
 


### PR DESCRIPTION
Steps:
1. Create a customer invoice with USD
2. Register payment with EUR
3. A payment with EUR and move with USD are created
4. When migrated to add move_id field to account_payment, then payment's
currency is not correct, because payment's currency is inherit from move