### PR TITLE
[MIG] [14.0] account: update Partner Types

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -375,7 +375,11 @@ def fill_empty_partner_type_account_payment(env):
         env.cr,
         """
         UPDATE account_payment
-        SET partner_type = 'customer'
+        SET partner_type =
+            CASE
+                WHEN payment_type = 'outbound' THEN 'supplier'
+                ELSE 'customer'
+            END
         WHERE partner_type IS NULL
         """,
     )


### PR DESCRIPTION
Do nhiều dữ liệu hiện tại của viindoo không thể phân loại nên sẽ chấp nhận sai số cho một số thanh toán không có kiểu đối tác từ 13.0

- Kiểu thanh toán là Nhận tiền -> kiểu đối tác là khách hàng
- Kiểu thanh toán là Chi tiền -> kiểu đối tác là nhà cung cấp