### PR TITLE
[FIX] apriori: wrong renamed_modules map

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -64,7 +64,7 @@ renamed_modules = {
     # Viindoo/erponline-enterprise
     "to_enterprice_marks_account": "to_enterprise_marks_account",
     "to_enterprice_marks_mrp": "to_enterprise_marks_mrp",
-    "to_hide_ent_modules_website_theme_install": "to_hide_ent_modules_website",
+    "to_hide_ent_modules_website_theme_install": "to_hide_ent_modules_website_theme",
 }
 
 # Merged modules contain a mapping from old module names to other,


### PR DESCRIPTION
`to_hide_ent_modules_website_theme_install` should become `to_hide_ent_modules_website_theme` instead of `to_hide_ent_modules_website`