### PR TITLE
[FIX][14.0] account: fill amount residual currency on account move line

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -771,6 +771,19 @@ def fill_account_move_line_amounts(env):
     )
 
 
+def fill_account_move_line_amount_residual_currency(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml
+        SET amount_residual_currency = aml.amount_residual
+        WHERE aml.company_currency_id = aml.currency_id
+            AND aml.amount_residual != 0
+            AND (aml.amount_residual_currency = 0
+                OR aml.amount_residual_currency IS NULL);""",
+    )
+
+
 def fill_account_move_line_date(env):
     openupgrade.logged_query(
         env.cr,
@@ -859,6 +872,7 @@ def migrate(env, version):
     pass_payment_to_journal_entry_narration(env)
     fill_company_account_cash_basis_base_account_id(env)
     fill_account_move_line_amounts(env)
+    fill_account_move_line_amount_residual_currency(env)
     fill_account_move_line_date(env)
     openupgrade.load_data(env.cr, "account", "14.0.1.1/noupdate_changes.xml")
     try_delete_noupdate_records(env)


### PR DESCRIPTION
Because currency_id on account_move_line is required on 14.0

PR at OCA: https://github.com/OCA/OpenUpgrade/pull/3212