### PR TITLE
[FIX][11.0] hr_recruitment: Fix migration script

### DIFF
--- a/addons/hr_recruitment/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_recruitment/migrations/11.0.1.0/post-migration.py
@@ -18,10 +18,12 @@ def fill_applicant_activities(env):
             ha.id,  im.id, im.model, ha.name, ha.title_action,
             %s, ha.date_action, ha.create_uid, ha.create_date,
             ha.write_uid, ha.write_date,
-            COALESCE(ha.user_id, hj.user_id, hd.manager_id, ha.create_uid)
+            COALESCE(ha.user_id, hj.user_id, rr.user_id, ha.create_uid)
          FROM hr_applicant AS ha
             INNER JOIN ir_model AS im ON im.model = 'hr.applicant'
             LEFT JOIN hr_department hd ON hd.id = ha.department_id
+            LEFT JOIN hr_employee he ON he.id = hd.manager_id
+            LEFT JOIN resource_resource rr ON rr.id = he.resource_id
             LEFT JOIN hr_job hj ON hj.id = ha.job_id
          WHERE
             title_action IS NOT NULL AND


### PR DESCRIPTION
Fix error when assigning id of hr.employee to the column of res.users

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
