### PR TITLE
[MIG][11.0] stock: Set noupdate for model 'procurement.order' to avoid error when re-upgrading module

### DIFF
--- a/addons/stock/migrations/11.0.1.1/end-migration.py
+++ b/addons/stock/migrations/11.0.1.1/end-migration.py
@@ -42,6 +42,28 @@ def merge_quants(env):
             )
 
 
+def noupdate_obsolete_model_records(cr):
+    """ Set noupdate = True for the obsolete model 'procurement.group' record,
+    so when we upgrade 'stock' module later, this model record will not be deleted,
+    which will raise error because this model is not declared in any python files.
+    """
+    models = [
+        'procurement.order'
+    ]
+    openupgrade.logged_query(
+        cr,
+        """
+        UPDATE ir_model_data
+        SET noupdate = TRUE
+        WHERE model = 'ir.model' AND res_id IN (
+            SELECT id FROM ir_model WHERE model IN %s
+        )
+        """,
+        (tuple(models), )
+    )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     merge_quants(env)
+    noupdate_obsolete_model_records(env.cr)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
