### PR TITLE
[FIX][14.0]base: remmove func delete_module_not_exist()

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
@@ -3,8 +3,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
 
-import odoo
-
 
 def fix_module_category_parent_id(env):
     # due to renames, we need to correct the parent_id
@@ -46,25 +44,8 @@ def fix_module_category_parent_id(env):
     )
 
 
-def delete_module_not_exist(env):
-    env.cr.execute("SELECT id, name from ir_module_module")
-    modules_to_delete = []
-    for module in env.cr.dictfetchall():
-        info = odoo.modules.module.load_information_from_description_file(
-            module["name"]
-        )
-        if info and info["installable"]:
-            continue
-        elif module != "studio_customization":
-            modules_to_delete.append(module["id"])
-    modules_to_delete = env["ir.module.module"].browse(modules_to_delete)
-    modules_to_delete.module_uninstall()
-    modules_to_delete.sudo().unlink()
-
-
 @openupgrade.migrate()
 def migrate(env, version):
     fix_module_category_parent_id(env)
     # Load noupdate changes
     openupgrade.load_data(env.cr, "base", "14.0.1.3/noupdate_changes.xml")
-    delete_module_not_exist(env)


### PR DESCRIPTION
Khi migration từ 13 lên 14, hàm này để xóa, gỡ các module đã đã bỏ. Việc này gây lỗi khi không tìm thấy module đã xóa.
```
Traceback (most recent call last):
  File "/home/thanhluan/virtualenv/python3.8/odoo14/lib/python3.8/site-packages/openupgradelib/openupgrade.py", line 2016, in wrapped_function
    func(
  File "/home/thanhluan/git/14.0/OpenUpgrade/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py", line 70, in migrate
    delete_module_not_exist(env)
  File "/home/thanhluan/git/14.0/OpenUpgrade/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py", line 61, in delete_module_not_exist
    modules_to_delete.module_uninstall()
  File "<decorator-gen-73>", line 2, in module_uninstall
  File "/home/thanhluan/git/14.0/odoo/odoo/addons/base/models/ir_module.py", line 74, in check_and_log
    return method(self, *args, **kwargs)
  File "/home/thanhluan/git/14.0/odoo/odoo/addons/base/models/ir_module.py", line 489, in module_uninstall
    self.env['ir.model.data']._module_data_uninstall(modules_to_remove)
  File "/home/thanhluan/git/14.0/odoo/odoo/addons/base/models/ir_model.py", line 2174, in _module_data_uninstall
    delete(self.env[model].browse(item[1] for item in items))
  File "/home/thanhluan/git/14.0/odoo/odoo/api.py", line 476, in __getitem__
    return self.registry[model_name]._browse(self, (), ())
  File "/home/thanhluan/git/14.0/odoo/odoo/modules/registry.py", line 177, in __getitem__
    return self.models[model_name]
KeyError: 'emoji'
```