### PR TITLE
[FIX][15.0] payment_transfer: fix migration

### DIFF
--- a/openupgrade_scripts/scripts/payment_transfer/15.0.2.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/payment_transfer/15.0.2.0/noupdate_changes.xml
@@ -1,9 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
   <record id="payment.payment_acquirer_transfer" model="payment.acquirer">
-    <field name="company_id"/>
     <field name="image_128" type="base64" file="payment_transfer/static/src/img/transfer_icon.png"/>
-    <field name="name"/>
     <field name="pending_msg" eval="False"/>
     <field name="redirect_form_view_id" ref="redirect_form"/>
     <field name="support_authorization">False</field>


### PR DESCRIPTION
Fix migration to module payment_transfer:
-Modify noupdate_change.xml because there are some incorrect information:
+) Deleted company_id and name field because when load noupdate_change.xml raise error company_id null violation and name field is null in database
![Screenshot from 2022-05-26 11-51-51](https://user-images.githubusercontent.com/56789189/170428136-acc9a092-11c2-4041-a780-2b9b6f5ef737.png)
![Screenshot from 2022-05-26 11-52-28](https://user-images.githubusercontent.com/56789189/170428150-b8138f49-f2eb-46c4-b6e2-38dd0c12169a.png)
)