### PR TITLE
[IMP+MIG][11.0] project: Set obsolete model project.issue to be non-updatable

### DIFF
--- a/addons/project/migrations/11.0.1.1/post-migration.py
+++ b/addons/project/migrations/11.0.1.1/post-migration.py
@@ -225,6 +225,9 @@ def migrate(env, version):
     set_default_values(env)
     if openupgrade.table_exists(env.cr, 'project_issue'):
         convert_issues(env)
+        openupgrade.set_xml_ids_noupdate_value(
+            env, 'project', ['model_project_issue'], True
+        )
     openupgrade.load_data(
         env.cr, 'project', 'migrations/11.0.1.1/noupdate_changes.xml'
     )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Set obsolete model `project.issue` to be non-updatable, so when re-upgrade the `project` module, Odoo will not try to delete the model and will not raise error.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
