### PR TITLE
[MISC][15.0] update apriori: l10n_vn* is merged, to_l10n_vn* is renamed

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -19,6 +19,7 @@ renamed_modules = {
     "to_slugify_l10n_vn": "viin_unicode_slugify",
     "to_res_state_group": "viin_base_state_group",
     "to_l10n_vn_hr_payroll": "l10n_vn_viin_hr_payroll",
+    "to_l10n_vn_picking_operation": "l10n_vn_viin_picking_operation",
     # Viindoo/erponline-enterprise
     "to_enterprise_marks_account": "viin_hide_ent_modules_account",
     "viin_mobile_notification_firebase": "viin_mobile_firebase",
@@ -32,6 +33,8 @@ renamed_modules = {
     "viin_enterprise_marks_sale": "viin_hide_ent_modules_sale",
     "viin_enterprise_marks_purchase": "viin_hide_ent_modules_purchase",
     "viin_enterprise_marks_website": "viin_hide_ent_modules_websitewebsite",
+    "to_l10n_vn_account_asset": "l10n_vn_viin_account_asset",
+    "to_l10n_vn_account_asset_sale": "l10n_vn_viin_account_asset_sale",
 }
 
 # Merged modules contain a mapping from old module names to other,
@@ -57,6 +60,11 @@ merged_modules = {
     "viin_crm_employee_size": "viin_crm_business_nature",
     "to_hr_public_employee_birthday_filters": "viin_hr_employee_birthday",
     "to_equipment_image": "viin_maintenance",
+    "l10n_vn_c133": "l10n_vn_viin",
+    "l10n_vn_c200": "l10n_vn_viin",
+    "l10n_vn_common": "l10n_vn_viin",
+    "to_account_financial_income": "viin_account",
+    "to_account_income_deduct": "viin_account",
     # Viindoo/odoo-tvtma
     "to_tvtma_crm": "viin_crm",
     "to_tvtma_sales": "viin_sale",


### PR DESCRIPTION
PR migration liên quan https://github.com/Viindoo/odoo-openupgrade-tvtmaaddons/pull/283

- 3 module l10n_vn_c133, l10n_vn_c200, l10n_vn_common merged thành l10n_vn_viin
- 2 module to_account_financial_income, to_account_income_deduct merged thành viin_account
- to_l10n_vn_picking_operation đổi tên thành l10n_vn_viin_picking_operation
- to_l10n_vn__account_asset -> l10n_vn_viin_account_asset (erp)
- to_l10n_vn_account_asset_sale -> l10n_vn_viin_account_asset_sale (erp)
 
Đã cập nhật trong file doc migratio 14->15 https://docs.google.com/document/d/1KpyYZB7rSbSMyaPQRJqLV3kAe3FT0Sj90JOSwR-qm9c/edit?pli=1#