### PR TITLE
[FIX][15.0] mail: only add followers for active user

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/pre-migration.py
@@ -83,6 +83,8 @@ def _add_follwers_from_mail_channel(env):
         SELECT mf.res_model, mf.res_id, mcp.partner_id from mail_followers mf
         join mail_channel mc on mf.channel_id = mc.id
         join mail_channel_partner mcp on mcp.channel_id = mc.id
+        join res_users ru on ru.partner_id = mcp.partner_id
+        WHERE ru.active = TRUE
         ON CONFLICT (res_model, res_id, partner_id) DO NOTHING
         """,
     )


### PR DESCRIPTION
Modify of https://github.com/Viindoo/OpenUpgrade/pull/303
-Chỉ nên add follow từ kênh mà người dùng đang hoạt động để tránh thừa bản ghi ko cần thiết
-Video test : https://drive.google.com/file/d/1nn1MTx2xWxRBWPqUTeDVS-xDmBIUAevL/view?usp=sharing