### PR TITLE
[IMP][15.0]website_slides: fill color to slide_channel_tag

### DIFF
--- a/openupgrade_scripts/scripts/website_slides/15.0.2.4/post-migration.py
+++ b/openupgrade_scripts/scripts/website_slides/15.0.2.4/post-migration.py
@@ -15,3 +15,11 @@ def migrate(env, version):
             "mail_notification_channel_invite",
         ],
     )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE slide_channel_tag
+        SET color = trunc(random() * 11 + 1)
+        WHERE color IS NULL;
+        """,
+    )


### PR DESCRIPTION
Lên phiên bản 15 nếu tag không có màu sẽ không hiển thị trên website, tại 14 trường này không có default tuy nhiên ở 15 lại có default từ 1-11 cho nên phải điền giá trị