### PR TITLE
[FIX][15.0] crm: rename field on custom view used on dashboard

### DIFF
--- a/openupgrade_scripts/scripts/crm/15.0.1.6/pre-migration.py
+++ b/openupgrade_scripts/scripts/crm/15.0.1.6/pre-migration.py
@@ -1,4 +1,57 @@
+import re
+
+from lxml import etree
 from openupgradelib import openupgrade
+
+
+def _rename_field_on_dashboard(env, model, old_field, new_field):
+    dashboard_view_data = env["ir.ui.view.custom"].search([])
+    for r in dashboard_view_data:
+        parsed_arch = etree.XML(r.arch)
+        act_window_ids = parsed_arch.xpath("//action/@name")
+        actions = env["ir.actions.act_window"].search(
+            [
+                ("id", "in", act_window_ids),
+                ("res_model", "=", model),
+            ]
+        )
+        for action in actions:
+            condition_for_element = "//action[@name='{}']".format(action.id)
+            condition_for_domain = "//action[@name='{}']/@domain".format(action.id)
+            condition_for_context = "//action[@name='{}']/@context".format(action.id)
+            arch_element = parsed_arch.xpath(condition_for_element)
+            for index in range(len(arch_element)):
+                arch_domain = arch_element[index].xpath(condition_for_domain)[index]
+                arch_context = arch_element[index].xpath(condition_for_context)[index]
+
+                arch_context = re.sub(
+                    r"""('group_by'|'col_group_by'|'graph_groupbys'
+                        |'pivot_measures'|'pivot_row_groupby'|'pivot_column_groupby'
+                        ):([\s*][^\]]*)'%s(:day|:week|:month|:year){0,1}'(.*?\])"""
+                    % old_field,
+                    r"\1:\2'%s\3'\4" % new_field,
+                    arch_context,
+                )
+
+                arch_context = re.sub(
+                    r"""'graph_measure':([\s*])'%s(:day|:week|:month|:year){0,1}'"""
+                    % old_field,
+                    r"'graph_measure':\1'%s\2'" % new_field,
+                    arch_context,
+                )
+
+                arch_domain = re.sub(
+                    r"""('|")%s('|")""" % old_field,
+                    r"\1%s\2" % new_field,
+                    arch_domain,
+                )
+
+                arch_element[index].set("domain", arch_domain)
+                arch_element[index].set("context", arch_context)
+
+            new_arch = etree.tostring(parsed_arch, encoding="unicode")
+
+            r.write({"arch": new_arch})
 
 
 @openupgrade.migrate()
@@ -12,4 +65,7 @@ def migrate(env, version):
             UPDATE crm_team_member
             SET assignment_max = 30;
         """,
+    )
+    _rename_field_on_dashboard(
+        env, "crm.lead", "activity_date_deadline_my", "my_activity_date_deadline"
     )


### PR DESCRIPTION
Lên 15, odoo bỏ trường activity_date_deadline_my vì nó trùng với trường my_activity_date_deadline của mail.activity.mixin rồi, nên sẽ dùng trường này thay vì activity_date_date_deadline_my , chi tiết ở commit `https://github.com/odoo/odoo/commit/6a1cda64f8d31f32cfe0ad13b3da8d8c7d7eda42`


Ảnh mà anh Minh log bug : 
![Screenshot from 2022-07-15 14-25-32](https://user-images.githubusercontent.com/56789189/179181092-b6f75560-0284-4b4e-bb8f-ca1d646f76fa.png)

-Video em test : https://drive.google.com/file/d/103Z3cuHcXHrDSAx4cYFd44fGui_7Ozk8/view?usp=sharing
