### PR TITLE
[FIX][12.0]account: migration do not delete action_invoice_tree2 because same key

### DIFF
--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -158,7 +158,7 @@ def drop_obsolete_fk_constraints(env):
 def migrate(env, version):
     cr = env.cr
     openupgrade.delete_records_safely_by_xml_id(
-        env, ['account.action_view_account_move_line_reconcile'],
+        env, ['account.action_view_account_move_line_reconcile', 'account.action_invoice_tree2'],
     )
     openupgrade.copy_columns(cr, _column_copies)
     openupgrade.rename_columns(cr, _column_renames)


### PR DESCRIPTION
ticket: https://viindoo.com/web#id=7784&menu_id=777&action=1076&active_id=7&model=helpdesk.ticket&view_type=form
openupgrade_analysis:
DEL ir.actions.act_window: account.action_invoice_tree2
NEW ir.actions.server: account.action_invoice_tree2