### PR TITLE
[FIX][[13.0] purchase: Fix bug miss migrate date_approved field

### DIFF
--- a/addons/purchase/migrations/13.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/13.0.1.2/post-migration.py
@@ -20,10 +20,10 @@ def change_type_purchase_order_date_approve(env):
         UPDATE purchase_order po
         SET date_approve = mm.date
         FROM mail_message mm
-        WHERE mm.subtype_id = %s
+        WHERE mm.subtype_id in %s
             AND mm.model = 'purchase.order'
             AND mm.res_id = po.id""",
-        (env.ref('purchase.mt_rfq_approved').id, ),
+        ((env.ref('purchase.mt_rfq_approved').id, env.ref('purchase.mt_rfq_confirmed').id, ), ),
     )
 
 


### PR DESCRIPTION
### Ticket: 
- [[BUG][14.0][Newland] Mua hàng: Mất dữ liệu "ngày phê duyệt" khi nâng cấp lên 14.0 (bản sao)](https://viindoo.com/web#id=8653&menu_id=89&action=1076&active_id=28943&model=helpdesk.ticket&view_type=form)

### Description:
- 12.0: Nếu người dùng xác nhân đơn mua với quyền admin thì subtype trong `mail_message` sẽ găn với bản ghi `mt_rfq_confirmed`, nhưng trong đoạn mã nguồn để migrate dữ liệu trường `date_approved` chỉ bắt điều kiện subtype với bản ghi `mt_rfq_approved` => các đơn mua do quyền admin xác nhận khi migrate nên 13.0 sẽ bị giá trị trường `date_approved`

