### PR TITLE
[FIX][14.0] account: Fix bug invoice data wrong when migrate 13.0 to 14.0

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
@@ -1,4 +1,9 @@
+import logging
+import threading
+from odoo.models import PREFETCH_MAX
 from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
 
 
 def _make_correct_account_type(env):
@@ -32,14 +37,72 @@ def _make_correct_account_type(env):
     )
 
 
+def _get_to_rec_number(todo, finished):
+    to_rec_number = finished + PREFETCH_MAX
+    remain = todo - finished
+    return to_rec_number if remain >= to_rec_number else remain
+
+
+def _switch_default_account_and_outstanding_account(env):
+    env.cr.execute("""
+        WITH sub AS(
+            SELECT aml.id AS aml_id,
+                am.id AS move_id,
+                aj.payment_debit_account_id,
+                aj.payment_credit_account_id
+            FROM account_move_line aml
+                JOIN account_move am ON aml.move_id = am.id
+                JOIN account_journal aj ON am.journal_id = aj.id
+            WHERE
+                AND aj.type IN ('bank', 'cash')
+                AND aml.account_internal_type = 'liquidity'
+                AND aml.statement_id IS NULL
+        )
+        UPDATE account_move_line aml
+        SET account_id =
+            CASE
+                WHEN aml.credit > 0 AND aml.debit = 0 THEN sub.payment_credit_account_id
+                WHEN aml.debit > 0 AND aml.credit = 0 THEN sub.payment_debit_account_id
+            END
+        FROM sub
+        WHERE aml.id = sub.aml_id
+            AND aml.display_type NOT IN ('line_section', 'line_note')
+        RETURNING sub.move_id
+    """)
+    moves_to_reload_counterpart = env['account.move'].search([('id', 'in', [rec[0] for rec in env.cr.fetchall()])])
+    records_count = len(moves_to_reload_counterpart)
+    finished = 0
+    for moves in env['to.base'].splittor(moves_to_reload_counterpart, PREFETCH_MAX):
+        _logger.info(
+            "start reload counterpart for journal items %s~%s in total %s records",
+            finished + 1, _get_to_rec_number(records_count, finished), records_count
+        )
+        with env.cr.savepoint():
+            moves.action_delete_counterpart()
+            moves.action_smart_create_counterpart()
+        finished += PREFETCH_MAX
+
+
 def _recompute_amount_residual(env):
     account_move_lines_to_recompute = env['account.move.line'].search([
         ('parent_state', '=', 'posted'),
-        ('move_id.payment_state', 'in', ['not_paid', 'in_payment', 'partial'])])
-    account_move_lines_to_recompute._compute_amount_residual()
+        ('currency_id', '!=', False),
+        ('amount_residual_currency', '=', 0.0)
+    ])
+    records_count = len(account_move_lines_to_recompute)
+    finished = 0
+    for lines in env['to.base'].splittor(account_move_lines_to_recompute, PREFETCH_MAX):
+        _logger.info(
+            "start computing amount residual currency for journal items %s~%s in total %s records",
+            finished + 1, _get_to_rec_number(records_count, finished), records_count
+        )
+        with env.cr.savepoint():
+            lines.with_context(skip_account_move_synchronization=True)._compute_amount_residual()
+        finished += PREFETCH_MAX
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    _recompute_amount_residual(env)
     _make_correct_account_type(env)
+    _switch_default_account_and_outstanding_account(env)
+    _recompute_amount_residual(env)

--- a/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
@@ -32,6 +32,14 @@ def _make_correct_account_type(env):
     )
 
 
+def _recompute_amount_residual(env):
+    account_move_lines_to_recompute = env['account.move.line'].search([
+        ('parent_state', '=', 'posted'),
+        ('move_id.payment_state', 'in', ['not_paid', 'in_payment', 'partial'])])
+    account_move_lines_to_recompute._compute_amount_residual()
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    _recompute_amount_residual(env)
     _make_correct_account_type(env)

--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -817,33 +817,6 @@ def _create_ir_config_parameter_constraint_start_date(env):
     )
 
 
-def _switch_default_account_and_outstanding_account(env):
-    openupgrade.logged_query(
-        env.cr,
-        """
-        WITH subquery as (
-            SELECT aml.id as aml_id,
-            aj.payment_debit_account_id,
-            aj.payment_credit_account_id,
-            aml.debit, aml.credit
-            FROM account_move_line aml
-            JOIN account_journal aj on aml.journal_id = aj.id
-            WHERE legacy_statement_unreconcile = TRUE
-            AND aj.type IN ('bank', 'cash')
-        )
-        UPDATE account_move_line aml
-        SET account_id =
-        CASE
-            WHEN subquery.debit > 0 THEN subquery.payment_debit_account_id
-            WHEN subquery.credit > 0 THEN subquery.payment_credit_account_id
-        END
-        FROM subquery
-        WHERE aml.id = subquery.aml_id
-        AND aml.display_type NOT IN ('line_section', 'line_note')
-        """,
-    )
-
-
 @openupgrade.migrate()
 def migrate(env, version):
     fill_account_journal_posted_before(env)
@@ -881,4 +854,3 @@ def migrate(env, version):
     )
     _migrate_currency_exchange_account_company(env)
     _create_ir_config_parameter_constraint_start_date(env)
-    _switch_default_account_and_outstanding_account(env)

--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -164,28 +164,6 @@ def copy_fields(env):
     )
 
 
-def _mark_move_line_statement_unreconciled(env):
-    # 1. create legacy_statement column in account_move_line table
-    openupgrade.logged_query(
-        env.cr,
-        """
-        ALTER TABLE account_move_line
-        ADD COLUMN IF NOT EXISTS legacy_statement_unreconcile BOOLEAN
-        """,
-    )
-
-    # 2. mark account move line is statement unreconciled in legacy_statement
-    openupgrade.logged_query(
-        env.cr,
-        """
-        UPDATE account_move_line
-        SET legacy_statement_unreconcile = TRUE
-        WHERE account_internal_type = 'liquidity'
-        AND statement_line_id IS NULL
-        """,
-    )
-
-
 def add_move_id_field_account_bank_statement_line(env):
     if not openupgrade.column_exists(
         env.cr, "account_bank_statement_line", "currency_id"
@@ -564,7 +542,6 @@ def migrate(env, version):
     openupgrade.set_xml_ids_noupdate_value(
         env, "account", ["account_analytic_line_rule_billing_user"], True
     )
-    _mark_move_line_statement_unreconciled(env)
     copy_fields(env)
     rename_fields(env)
     m2m_tables_account_journal_renamed(env)


### PR DESCRIPTION
### Ticket:
- [[BUG][MIG][Kế toán][Newlando14]- Không thể thực hiện thanh toán với những hóa đơn cũ chưa thanh toán hoặc thnh toán 1 phần](https://viindoo.com/web#id=8668&menu_id=89&model=helpdesk.ticket&view_type=form)
- [[BUG][MIG][Kế toán][Newlando14]- Không thêm được thanh toán vào Hóa đơn KH/NCC](https://viindoo.com/web#id=8678&menu_id=89&model=helpdesk.ticket&view_type=form)
### Mô tả:
- Các hóa đơn đã thanh toán một phần tiền từ 13 -> 14 sai do 14.0 bổ sung thêm trạng thái thanh toán là  'partial' (13.0 chưa có state này)
- Khi migration từ 13 -> 14 có một số bản ghi trạng thái chưa thanh toán và đã thanh toán một phần bị giá trị 'NULL'