### PR TITLE
[IMP][15.0] openupgrade_scripts: add module renamed to apriori.py

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -27,6 +27,7 @@ renamed_modules = {
     "viin_l10n_vn_accounting_sinvoice": "l10n_vn_viin_accounting_sinvoice",
     "to_l10n_vn_hr_payroll_account": "l10n_vn_viin_hr_payroll_account",
     "to_l10n_vn_hr_payroll_meal_account": "l10n_vn_viin_hr_payroll_meal_account",
+    "to_l10n_vn_stock_reports": "l10n_vn_viin_stock_reports",
     # Viindoo/erponline-enterprise
     "to_enterprise_marks_account": "viin_hide_ent_modules_account",
     "viin_mobile_notification_firebase": "viin_mobile_firebase",


### PR DESCRIPTION
- Bổ sung tên module đổi tên: to_l10n_vn_stock_reports nên 15.0 được đổi tên thành l10n_vn_viin_stock_reports