### PR TITLE
[MIG][15.0] hr_expense: apply recompute for records hr.expense have'nt sheet_id

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/15.0.2.0/end-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/15.0.2.0/end-migration.py
@@ -1,0 +1,11 @@
+from openupgradelib import openupgrade
+
+
+def recompute_total_amount_company(env):
+    expense_to_recompute = env["hr.expense"].search([("sheet_id", "=", False)])
+    expense_to_recompute._compute_total_amount_company()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    recompute_total_amount_company(env)

--- a/openupgrade_scripts/scripts/hr_holidays/15.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/15.0.1.5/post-migration.py
@@ -2,11 +2,6 @@ import logging
 
 from openupgradelib import openupgrade
 
-from odoo import api
-from odoo.exceptions import ValidationError
-
-from odoo.addons.hr_holidays.models.hr_leave import HolidaysRequest
-
 _logger = logging.getLogger(__name__)
 
 
@@ -49,7 +44,7 @@ def _map_hr_leave_allocation_date_to(env):
             WHERE id IN %s
             """
             % (
-                openupgrade.get_legacy_name("date_to"), 
+                openupgrade.get_legacy_name("date_to"),
                 tuple(allocations_to_update.ids),
             ),
         )


### PR DESCRIPTION
### Ticket:
- [[Q&A][MIG15][Novamed]: Cách tính tổng tiền trên chi tiêu](https://viindoo.com/web#id=9134&cids=1&action=1076&active_id=215&model=helpdesk.ticket&view_type=form)
### Description:
- Do cơ chế tính tổng tiền của các bản ghi chi phí giữa 14.0 và 15.0 khác nhau, tuy migrate dữ liệu đảm bảo đúng nhưng về mặt bản chất tính năng là sai.
- Đối với những bản ghi **Chi tiêu** (`hr.expense`) ở 14.0 không có **Bản kê** (`sheet_id`) thì **Tổng tiền theo công ty** (`total_amount_company`) không được tính toán do trường `currency_company_id`  related tới `hr.expense.sheet`để lấy giá trị tiền tệ từ **Bản kê** được liên kết. Nhưng 15.0, trường `currency_company_id`  related tới `res.company`  dẫn đến các bản ghi **Chi tiêu** mặc dừ ở trạng thái dự thảo nhưng giá trị của trường `total_amount_company` vẫn được tính toán. Do vậy, Đối với những bản ghi dữ liệu từ 14.0 migrate nên 15.0 mà không có `sheet_id` **Bản kê** cần chạy lại `_compute_total_amount_company()` để trường `total_amount_company` được tính toán lại.