### PR TITLE
[FIX][15.0] account: fix bug migrate wrong field payment_method_line_id

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
@@ -290,7 +290,8 @@ def _fast_fill_account_payment_payment_method_line_id(env):
         SET payment_method_line_id = apml.id
         FROM account_move am
         JOIN account_payment_method_line apml ON apml.journal_id = am.journal_id
-        WHERE ap.move_id = am.id
+        JOIN account_payment_method apm ON apml.payment_method_id = apm.id
+        WHERE ap.move_id = am.id AND apm.payment_type = ap.payment_type
         """,
     )
 


### PR DESCRIPTION
### Ticket:
- [[BUG][MIG15][Novamed][Advance]: Chi tiết thanh toán tạm ứng bị thiếu trường](https://viindoo.com/web?debug=1#id=9115&cids=1&action=1076&active_id=215&model=helpdesk.ticket&view_type=form)

### Description
- Do khi migrate lên 15.0 trường `payment_method_line_id` trong model `account.payment` sai -> không thể tính toán được trường `reconciled_statement_ids` và `reconciled_statements_count` để hiển thị nên smart button **Sổ phụ**