### PR TITLE
[MIG+FIX][15.0] board: migration delete context on customized views

### DIFF
--- a/openupgrade_scripts/scripts/board/15.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/board/15.0.1.0/pre-migration.py
@@ -1,0 +1,33 @@
+import ast
+import re
+
+from lxml import etree
+from openupgradelib import openupgrade
+
+
+def _delete_context_on_dashboard(env, keys):
+    regex_keys_match = [re.compile("%s" % key) for key in keys]
+    dashboard_view_data = env["ir.ui.view.custom"].search([])
+    for r in dashboard_view_data:
+        parsed_arch = etree.XML(r.arch)
+        act_window_ids = parsed_arch.xpath("//action/@name")
+        actions = env["ir.actions.act_window"].search([("id", "in", act_window_ids)])
+        for action in actions:
+            condition_for_element = "//action[@name='{}']".format(action.id)
+            condition_for_context = "//action[@name='{}']/@context".format(action.id)
+            arch_element = parsed_arch.xpath(condition_for_element)
+            for index in range(len(arch_element)):
+                arch_context = arch_element[index].xpath(condition_for_context)[index]
+                arch_context = {
+                    k: v
+                    for k, v in ast.literal_eval(str(arch_context)).items()
+                    if not any(re.fullmatch(regex, k) for regex in regex_keys_match)
+                }
+                arch_element[index].set("context", str(arch_context))
+            new_arch = etree.tostring(parsed_arch, encoding="unicode")
+            r.write({"arch": new_arch})
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _delete_context_on_dashboard(env, ["allowed_company_ids"])


### PR DESCRIPTION
PR xử lý cho ticket: [9154](https://viindoo.com/web#id=9154&cids=1&model=helpdesk.ticket&view_type=form)

PR mig xoá key `allowed_company_ids` trong Customized Views
Nguyên nhân: Em kiểm tra từ bản 13 thì khi tạo dashboard thì Odoo đã loại bỏ `allowed_company_ids` trong context và xử lý công ty theo logic khác nên gây ra lỗi khi chuyển công ty vẫn thấy đc dashboard
PR Odoo: `https://github.com/odoo/odoo/pull/94074`

Note: do dựng trên bản cũ dưới local custom view cũng không còn key đó context nên em đã test bằng cách tự thêm thủ công rồi chạy MIG. Nên e xin phép cập nhật video sau nếu cần thiết ạ

https://user-images.githubusercontent.com/41574005/199904794-2cf50ecc-83f3-45d9-9c50-280ae72a8e72.mp4



