### PR TITLE
[MIG][15.0] hr_expense: add migration for field unit_amount

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/15.0.2.0/end-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/15.0.2.0/end-migration.py
@@ -6,6 +6,27 @@ def recompute_total_amount_company(env):
     expense_to_recompute._compute_total_amount_company()
 
 
+def update_expense_unit_amount(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE hr_expense
+        SET unit_amount = 0.0
+        WHERE id IN (
+            SELECT he.id
+            FROM hr_expense he
+            JOIN product_product pp ON he.product_id = pp.id
+            LEFT JOIN ir_property ip ON ip.name = 'standard_price'
+                AND ip.res_id = CONCAT('product.product,', pp.id)
+                AND he.company_id = ip.company_id
+            WHERE  he.unit_amount != 0.0
+                AND ip.value_float IS NULL
+        )
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    update_expense_unit_amount(env)
     recompute_total_amount_company(env)


### PR DESCRIPTION
### Tiket:
- [[MIG 15] Novamed - Chi tiêu | Migrate dữ liệu chi tiêu từ 14 - 15 hiển thị dữ liệu không chính xác](https://viindoo.com/web#id=9207&cids=1&action=1076&active_id=215&model=helpdesk.ticket&view_type=form)

### Description:
**1, HIỆN TRẠNG:** 

| **Trường** | **Chi tiêu 14.0**  | **Chi tiêu 15.0** |
| :-------------: | :-------------: | :-------------: |
| Đơn giá [`unit_amount`] | Hiển thị trên view, là trường compute nhưng có thể chỉnh sửa, có lưu trong database. | Chỉ hiển thị trên view khi có giá trị, là trường compute không thể thể chỉnh sửa, có lưu trong database. |
| Thuế [`tax_ids`] | Hiển thị trên view, cho phép chỉnh sửa, không có **domain** | Ẩn đi trên view khi **Đơn giá** của Chi tiêu khác `0`, có **domain** lọc ra các **Thuế bao gồm trong giá** |
| Tổng [`total_amount`] | Là trường compute, có lưu trong database | Là trường compute, ẩn đi khi Sản phẩm của chi tiêu có giá vốn, có lưu trong database |

**- Note: Trên 15.0, Chi tiêu chỉ hiển thị **Đơn giá** khi sản phẩm của Chi tiêu đó được thiết lập giá vốn**

**2, VẤN ĐỀ GẶP PHẢI:**
- Trên 15.0, Chi tiêu có sản phẩm không có giá vốn nhưng **Đơn giá** vẫn hiện trên form view

**3, NGUYÊN NHÂN:**
- Do trường **Đơn giá (`unit_amount`)**  vẫn còn giá trị cũ từ 14.0 nên trường **Thuế** (`tax_ids`) bị ần đi.

**4, GIẢI PHÁP:**
- Cần thiết lập **Đơn giá** (`unit_amount`)  về `0` đối với các **Chi tiêu** có sản phẩm không có giá vốn nhưng vẫn có **Đơn giá (`unit_amount`)**  trên **Chi tiêu** ở 14.0 khi migrate lên 15.0.

**Note**: (Nếu cập nhật giá trị  trường **Đơn giá** (`unit_amount`) bằng ORM thì sẽ kích hoạt hàm compute nhưng dùng SQL thì sẽ không ảnh hưởng tới giá trị của các trường khác.)