### PR TITLE
[IMP][16.0] apriori: rename module

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -32,6 +32,7 @@ renamed_modules = {
     "viin_product_categ_mail_thread_purchase": "viin_mail_thread_purchase",
     "viin_product_categ_mail_thread_stock_account": "viin_mail_thread_stock_account",
     "viin_webp": "viin_web_editor",
+    "viin_user_assignment_log_project": "test_viin_user_assignment_log_project",
     # Viindoo/enterprise
     # Viindoo/odoo-tvtma
 }


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
https://viindoo.com/web#id=66454&cids=1&menu_id=289&action=409&active_id=231&model=project.task&view_type=form

Description:
Rename module viin_user_assignment_log_project to test_viin_user_assignment_log_project

--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit