### PR TITLE
[IMP][16.0] apriori: Renamed modules

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -29,6 +29,7 @@ renamed_modules = {
     "to_stock_backdate": "viin_stock_backdate",
     "to_stock_picking_backdate": "viin_stock_account_backdate",
     "to_uom_mail_thread": "viin_mail_thread_uom",
+    "to_stock_production_lot_partner_infor": "viin_stock_lot_partner_infor",
     "viin_google_drive_support_oauth2": "viin_google_drive",
     "viin_product_categ_mail_thread_purchase": "viin_mail_thread_purchase",
     "viin_product_categ_mail_thread_stock_account": "viin_mail_thread_stock_account",


### PR DESCRIPTION
Reference of the issue/task this PR addresses:
[to_stock_production_lot_partner_infor](https://viindoo.com/web#id=65568&cids=1&menu_id=289&action=409&active_id=231&model=project.task&view_type=form)

Description:
Renamed module to_stock_production_lot_partner_infor to viin_stock_lot_partner_infor

--
I confirm I have read guidelines at https://docs.google.com/document/d/1Ru1C9XK93BNmXX1nKvTMt63QMBIOBy2NSdKosEwvuy4/edit