### PR TITLE
[FIX][16.0] base: Fix migration script for translation

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -66,7 +66,8 @@ def update_translatable_fields(cr):
                     bool_or(imd.noupdate) AS noupdate
                 FROM ir_translation it
                 LEFT JOIN ir_model_data imd ON imd.model = %(model)s AND imd.res_id = it.res_id
-                WHERE it.type = 'model' AND it.name = %(name)s AND it.state = 'translated'
+                WHERE it.lang IS NOT NULL AND it.type = 'model'
+                    AND it.name = %(name)s AND it.state = 'translated'
                 GROUP BY it.res_id
             )
             UPDATE "%(table)s" m


### PR DESCRIPTION
Trong DB nếu có các bản ghi `ir.translation` mà `lang` = `null` thì khi chạy query convert sang json sẽ gặp lỗi sau:
```
error: field name must not be null
```
Các bản ghi này tồn tại từ các phiên bản cũ, bản chất cũng ko hợp lệ nên có thể bỏ qua trong quá trình convert.