### PR TITLE
[16.0][IMP] mail: delete duplicate mail noti record before creating constrain

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
@@ -97,6 +97,17 @@ def _to_mail_notif_and_email_create_mail_notification_index(env):
         [("name", "=", "to_mail_notif_and_email"), ("state", "=", "to upgrade")]
     )
     if module_to_mail_notif_and_email:
+        openupgrade.logged_query(
+            env.cr,
+            """
+            DELETE FROM mail_notification mn1
+                  USING mail_notification mn2
+            WHERE mn1.id > mn2.id
+            AND mn1.mail_message_id = mn2.mail_message_id
+            AND mn1.res_partner_id = mn2.res_partner_id
+            AND mn1.notification_type = mn2.notification_type;
+            """,
+        )
         env.cr.execute(
             """
             CREATE UNIQUE INDEX IF NOT EXISTS unique_mail_message_id_res_partner_id_if_set


### PR DESCRIPTION
Closed https://github.com/Viindoo/OpenUpgrade/issues/523
Comment : https://github.com/Viindoo/OpenUpgrade/pull/465#issuecomment-1678362078
-So duplicate mail notification might exist (mail_message_id, res_partner_id, notification_type) which make it fail to add a constrain related with module to_mail_notif_and_email, so we delete duplicate one
Video test:


https://github.com/Viindoo/OpenUpgrade/assets/56789189/8f4ef8fd-7aac-43d3-b3ae-0a6e17935546



