### PR TITLE
[16.0][FIX] mail: mail_channel name updated not correctly

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
@@ -117,8 +117,27 @@ def _to_mail_notif_and_email_create_mail_notification_index(env):
         )
 
 
+def _update_mail_channel_name(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        WITH sub AS(
+            SELECT res_id, value FROM _ir_translation
+            WHERE name = 'mail.channel,name'
+            AND value IS NOT NULL
+            AND src != value
+        )
+        UPDATE mail_channel mc
+        SET name = sub.value
+        FROM sub
+        WHERE mc.id = sub.res_id
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    _update_mail_channel_name(env)
     delete_obsolete_constraints(env)
     openupgrade.rename_fields(env, _fields_renames)
     openupgrade.rename_models(env.cr, _models_renames)


### PR DESCRIPTION
Ticket liên quan: https://viindoo.com/web#id=48915&cids=1&menu_id=777&action=1074&active_id=39&model=helpdesk.ticket&view_type=form
field name of the model mail.channel no longer translate, so in the migration process it will try to update base on the translation, when we try to duplicate a mail channel it will create 2 ir.translation record both has the same 'src' equal to the one we have duplicated, then that channel will update the name from the 'src', not correct