### PR TITLE
[FIX][16.0] mail: mail channel privacy

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
@@ -1,0 +1,34 @@
+from openupgradelib import openupgrade
+
+
+def _mail_channel_privacy(env):
+    """
+    Since Odoo 16, configure a private channel can be complicated
+    Therefore we Viindoo provide a module that can make thing easier
+    Check it out at https://viindoo.com/apps/app/16.0/viin_mail_channel_privacy
+    or if you can't find it, just go to https://viindoo.com/apps
+    then search for 'viin_mail_channel_privacy' to test this feature.
+    """
+    if "is_private" not in env["mail.channel"]._fields:
+        return
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE mail_channel
+        SET is_private = true
+        WHERE public = 'private' AND channel_type = 'channel'
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE mail_channel
+        SET group_public_id = NULL AND channel_type = 'channel'
+        WHERE public = 'public'
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _mail_channel_privacy(env)

--- a/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
@@ -23,8 +23,8 @@ def _mail_channel_privacy(env):
         env.cr,
         """
         UPDATE mail_channel
-        SET group_public_id = NULL AND channel_type = 'channel'
-        WHERE public = 'public'
+        SET group_public_id = NULL
+        WHERE public = 'public' AND channel_type = 'channel'
         """,
     )
 

--- a/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
@@ -135,6 +135,14 @@ def _update_mail_channel_name(env):
     )
 
 
+def _force_install_viin_mail_channel_privacy_module(env):
+    viin_mail_channel_privacy_module = env["ir.module.module"].search(
+        [("name", "=", "viin_mail_channel_privacy")]
+    )
+    if viin_mail_channel_privacy_module:
+        viin_mail_channel_privacy_module.button_install()
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _update_mail_channel_name(env)
@@ -151,3 +159,4 @@ def migrate(env, version):
     # This method is only exist in Viindoo/Openupgrade for some
     # Technical reason
     _to_mail_notif_and_email_create_mail_notification_index(env)
+    _force_install_viin_mail_channel_privacy_module(env)


### PR DESCRIPTION
ticket liên quan: https://viindoo.com/web#id=49012&cids=1&menu_id=777&action=1075&model=helpdesk.ticket&view_type=form

Odoo bỏ trường `public` trên `mail.channel` , tính `private` của mail_channel giờ sẽ được dựa trên group , cụ thể là trường `group_public_id` chi tiết ở `https://github.com/odoo/odoo/commit/d57c64f95b824983be2baedfcd57f0e128c52b34`

Giải pháp sử dụng module mới trên 16 của Viindoo là  `viin_mail_channel_privacy`

PR liên quan:https://github.com/Viindoo/odoo-openupgrade-tvtmaaddons/pull/492