### PR TITLE
[FIX] translated fields at backend no update correctly

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/fields.py
+++ b/openupgrade_framework/odoo_patch/odoo/fields.py
@@ -17,6 +17,11 @@ def _convert_db_column(self, model, column):
         for query in itertools.chain.from_iterable(
             _get_translation_upgrade_queries(model._cr, self)
         ):
+            # We want to take the translation value instead
+            query = query.replace(
+                'ELSE t.value || m."%s" END' % self.name,
+                'ELSE m."%s" || t.value END' % self.name,
+            )
             openupgrade.logged_query(model._cr, query)
 
 


### PR DESCRIPTION
When a field is translated odoo will try to convert to jsonb column first, Ex: First create a Partner with name something like 'Nguyễn Đại Dương' then odoo will create 2 ir.translation record with 2 lang are 'en_US' and 'vi_VN' both have 'src' field is 'Nguyễn Đại Dương'. We want to edit the name 'Nguyễn Đại Dương' has the English version is  'MessD' and Vietnam version still 'Nguyễn Đại Dương'.
So when in migration process, first Odoo convert the 'name' into jsonb column but take the value in the database not from ir.translation, and we have {'en_US': 'Nguyễn Đại Dương'} and then at the step 'update_translation' for translated field the actual value will consider the 'ir.translation' and we have {'en_US': 'MessD', 'vi_VN': 'Nguyễn Đại Dương'}.
In the updated query the 'SET "{field.name}" = CASE WHEN t.noupdate THEN m."{field.name}" || t.value ELSE t.value || m."{field.name}" END' will remove the {'en_us': 'MessD'} and now we only have {'en_US': 'Nguyễn Đại Dương', 'vi_VN': 'Nguyễn Đại Dương'}