### PR TITLE
[FIX] [16.0] hr_holidays: re-update number of days of allocations

### DIFF
--- a/openupgrade_scripts/scripts/hr_holidays/16.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/16.0.1.5/post-migration.py
@@ -22,7 +22,22 @@ def set_allocation_validation_type(env):
     )
 
 
+def _fix_number_of_days_allocation(env):
+    allocations = (
+        env["hr.leave.allocation"]
+        .with_context(active_test=False)
+        .search([("parent_id.type_request_unit", "=", "hour")])
+    )
+    for allocation in allocations:
+        hours_per_day = (
+            allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day
+        )
+        if hours_per_day and hours_per_day != 8.0:
+            allocation.number_of_days = (allocation.number_of_days * 8) / hours_per_day
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     set_allocation_validation_type(env)
     openupgrade.load_data(env.cr, "hr_holidays", "16.0.1.5/noupdate_changes.xml")
+    _fix_number_of_days_allocation(env)


### PR DESCRIPTION
re-update number of days of allocations because `_compute_number_of_hours_display` changed

ticket: https://viindoo.com/web#id=48956&cids=1&menu_id=777&action=1074&active_id=39&model=helpdesk.ticket&view_type=form