### PR TITLE
[FIX][16.0] openupgrade_framework: remove redundant domain to correctly update view

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/models.py
+++ b/openupgrade_framework/odoo_patch/odoo/models.py
@@ -9,6 +9,8 @@ from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 _logger = logging.getLogger(__name__)
 
+NEED_UPDATED_VIEWS_KEYS = ["website.record_cover"]
+
 
 def unlink(self):
     """Don't break on unlink of obsolete records
@@ -58,9 +60,12 @@ def _load_records(self, data_list, update=False):
             related_records = self.env["ir.ui.view"].search(
                 [
                     ("id", "!=", original_record.id),
-                    ("key", "=", original_record.key),
                     ("type", "=", "qweb"),
                     ("website_id", "!=", False),
+                    ("key", "=", original_record.key),
+                    "|",
+                    ("key", "in", NEED_UPDATED_VIEWS_KEYS),
+                    "&",
                     ("arch_db", "=", original_record.arch_db),
                     ("inherit_id", "!=", False),
                 ]


### PR DESCRIPTION
ticket liên quan: https://viindoo.com/web?debug=1#id=49495&cids=1&menu_id=89&model=helpdesk.ticket&view_type=form

Step to reproduce:

Cài webite_blog ở 15, trên 1 blog bất kỳ thực hiện thay ảnh cover của bài blog đó, lúc này hệ thống sẽ sinh ra 1 bản ghi `ir.ui.view` cùng key đó là `website.record_cover`, nghĩa là trong hệ thống có 2 ông `website.record_cover` 1 ông có website_id, 1 ông thì ko.
Khi migrate lên thì chỉ ông gốc được update view theo code 16, ông mới sinh ra ko được nên khi thay ảnh cover ở 16 nó ko nhận ảnh mới