### PR TITLE
[IMP][17.0] hr_timesheet: fill timesheet_time base on date of project.update

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/17.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_timesheet/17.0.1.0/post-migration.py
@@ -1,19 +1,44 @@
+from collections import defaultdict
+
 from openupgradelib import openupgrade
 
 
 def _project_update_fill_timesheet(env):
     updates = env["project.update"].with_context(active_test=False).search([])
+    timesheets_read_group = env["account.analytic.line"]._read_group(
+        [
+            (
+                "project_id",
+                "in",
+                env["project.project"].with_context(active_test=False).search([]).ids,
+            )
+        ],
+        ["project_id", "product_uom_id", "date:day"],
+        ["unit_amount:sum"],
+    )
+    timesheet_time_dict = defaultdict(list)
+    for project, product_uom, date, unit_amount_sum in timesheets_read_group:
+        timesheet_time_dict[project.id].append((product_uom, date, unit_amount_sum))
     for update in updates:
         project = update.project_id
         encode_uom = project.company_id.timesheet_encode_uom_id
         if not encode_uom:
             continue
+
+        total_time = 0.0
+        for product_uom, date, unit_amount in timesheet_time_dict[project.id]:
+            if date > update.date:
+                continue
+            factor = (product_uom or project.timesheet_encode_uom_id).factor_inv
+            total_time += unit_amount * (1.0 if project.encode_uom_in_days else factor)
+        total_time *= project.timesheet_encode_uom_id.factor
+
         ratio = env.ref("uom.product_uom_hour").ratio / encode_uom.ratio
         update.write(
             {
                 "uom_id": encode_uom,
                 "allocated_time": round(project.allocated_hours / ratio),
-                "timesheet_time": round(project.total_timesheet_time / ratio),
+                "timesheet_time": round(total_time / ratio),
             }
         )
 


### PR DESCRIPTION
Close #650

-Currently we fill all project update with same timesheet time while it should be fill base on date, mean that if we have 2 project update of a project have more than 1 day apart, the timesheet to be taken account will only get to the 'date' of project.update.

EXAMPLE:
In v16 we have
-PU 1: 01/01/2024 have total 10 timesheet line with total unit amount is 50 hours -> v17 timesheet_time is 50 hours
-PU 2: after a week (08/01/2024) create PU 2 now will increase timesheet line to 15 with total unit amount is 70 hours -> v17 timesheet_time is 70 hours