### PR TITLE
[16.0][FIX] payment: Need to install the `account_payment` module to avoid errors

### DIFF
--- a/openupgrade_scripts/scripts/account/16.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/post-migration.py
@@ -25,6 +25,7 @@ _deleted_xml_records = [
 
 _modules_to_install = [
     "account_sequence",
+    "account_payment"
 ]
 
 


### PR DESCRIPTION
# What is this PR for ?
- Because the field `authorized_transaction_ids` is moved from `payment` to `account_payment`,  we need to install the `account_payment` module  to avoid errors.