### PR TITLE
[FIX][16.0] account: Use Anglo-Saxon Accounting display type case cogs

### DIFF
--- a/openupgrade_scripts/scripts/account/16.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/pre-migration.py
@@ -282,6 +282,7 @@ def _account_move_fast_fill_display_type(env):
                     WHEN aml.tax_line_id IS NOT NULL THEN 'tax'
                     WHEN aa.account_type IN
                     ('asset_receivable', 'liability_payable') THEN 'payment_term'
+                    WHEN aml.cogs_origin_id IS NOT NULL THEN 'cogs'
                     ELSE 'product'
                 END AS display_type
             FROM account_move_line AS aml


### PR DESCRIPTION
Phân loại thiếu với trường hợp công ty sử dụng kế toán  Anglo-Saxon 

https://github.com/Viindoo/odoo/blob/455b42a67bbaa71db099faec10b7afabfc7ec658/addons/stock_account/models/account_move.py#L79

