### PR TITLE
[FIX] l10n_vn: fix mig format xmlid

### DIFF
--- a/openupgrade_scripts/scripts/l10n_vn/17.0.2.0.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_vn/17.0.2.0.3/pre-migration.py
@@ -233,7 +233,7 @@ def _vn_coa_rename_xml_id(env):
                 .ref(xmlid, raise_if_not_found=False)
             ):
                 continue
-            old_xmlid = f"l10n_vn.{xmlid}"
+            old_xmlid = f"l10n_vn.{company_id}_{xmlid}"
             new_xmlid = f"account.{company_id}_{xmlid}"
             xmlids_renames.append((old_xmlid, new_xmlid))
     openupgrade.rename_xmlids(env.cr, xmlids_renames)


### PR DESCRIPTION
V16: xmlid có dạng f"module.{company_id}_{xmlid}" đoạn code gốc xử lý [code](https://github.com/Viindoo/odoo/blob/65ff062c347e921d10e2879b0e9263bccb7df825/addons/account/models/chart_template.py#L933)

viin_account có đoạn code xử lý có thể là xử lý [(code)](https://github.com/Viindoo/tvtmaaddons/blob/18d517060216153f80460c1a5c58fb2203ab1ecb/viin_account/models/res_company.py#L85). Có thể là sửa dữ liệu mig 15 lên 16

Openuprade/account đã sửa lại xmlid [(code)](https://github.com/Viindoo/OpenUpgrade/blob/50db35bb33bc3a97c24deade764f02dddbf9e4df/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py#L531) nên đến mig l10n_vn xmid đã được sửa rồi, đã có đoạn check xmlid để không đi sửa. Mà cả đoạn code `_vn_coa_rename_xml_id` có thể bỏ đi vì đã được xử lý ở mig account

