### PR TITLE
[MIG][17.0] website:Update the path changed by _match_asset_file_url_regex

### DIFF
--- a/openupgrade_scripts/scripts/website/17.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/17.0.1.0/post-migration.py
@@ -5,6 +5,57 @@
 from openupgradelib import openupgrade
 
 
+def update_ir_attachment_urls(env):
+    """Update ir_attachment URLs for SCSS files."""
+    # Update user_values.scss files
+    # Find assets with target path, get their current path, and update attachments with matching url
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_attachment att
+        SET url = '/_custom/web.assets_frontend/website/static/src/scss/options/user_values.scss'
+        FROM ir_asset asset
+        WHERE asset.target = '/website/static/src/scss/options/user_values.scss'
+            AND att.url = asset.path
+        """,
+    )
+    # Update user_color_palette.scss files
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_attachment att
+        SET url = '/_custom/web.assets_frontend/website/static/src/scss/options/colors/user_color_palette.scss'
+        FROM ir_asset asset
+        WHERE asset.target = '/website/static/src/scss/options/colors/user_color_palette.scss'
+            AND att.url = asset.path
+        """,
+    )
+
+
+def update_ir_asset_paths(env):
+    """Update ir.asset paths for SCSS files."""
+    # Update user_values.scss files
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_asset
+        SET path = '/_custom/web.assets_frontend/website/static/src/scss/options/user_values.scss'
+        WHERE target = '/website/static/src/scss/options/user_values.scss'
+        """,
+    )
+    # Update user_color_palette.scss files
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_asset
+        SET path = '/_custom/web.assets_frontend/website/static/src/scss/options/colors/user_color_palette.scss'
+        WHERE target = '/website/static/src/scss/options/colors/user_color_palette.scss'
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    update_ir_attachment_urls(env)
+    update_ir_asset_paths(env)
     openupgrade.load_data(env, "website", "17.0.1.0/noupdate_changes.xml")


### PR DESCRIPTION
[[BUG][17.0] Viindoo Upgrade 17.0: Trang chủ website Viindoo lỗi CSS](https://viindoo.com/web#id=59704&cids=1&menu_id=123&model=viin.helpdesk.ticket&view_type=form)

_match_asset_file_url_regex đổi từ `re.compile(r"^/(\w+)/(.+?)(\.custom\.(.+))?\.(\w+)$") `

thành `re.compile(r"^(/_custom/([^/]+))?/(\w+)/([/\w]+\.\w+)$")`

và hàm _get_data_from_url kiểm tra url hợp kệ thông qua _match_asset_file_url_regex để lấy dữ liệu custom => nếu url cũ như 16 sẽ không hợp lệ => cần update lại url cũ thành url hợp lệ

<img width="587" height="305" alt="Screenshot 2025-11-12 at 11 56 38 AM" src="https://github.com/user-attachments/assets/b9c9011f-fa28-47c1-a4eb-0713e217101b" />

đã đổi trên 17.0
<img width="930" height="288" alt="Screenshot 2025-11-12 at 11 53 19 AM" src="https://github.com/user-attachments/assets/56608783-78ca-4049-af3e-4007bfe85664" />
