### PR TITLE
[FIX] account: fix assing journal xmlids

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/end-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/end-migration.py
@@ -21,10 +21,15 @@ def _assign_journal_xmlids(env):
         for xmlid, journal_data in list(
             template_data.get("account.journal", {}).items()
         ):
-            if not env.ref(xmlid, raise_if_not_found=False) and "type" in journal_data:
+            if (
+                not env.ref(xmlid, raise_if_not_found=False)
+                and "type" in journal_data
+                and "code" in journal_data
+            ):
                 journal = existing_journals.filtered(
                     lambda j: j.type == journal_data["type"]  # noqa: B023
-                )[:1]
+                    and j.code == journal_data["code"]  # noqa: B023
+                )
                 if journal:
                     existing_journals -= journal
                     env["ir.model.data"]._update_xmlids(


### PR DESCRIPTION
Tkcet: https://viindoo.com/web#id=60123&cids=1&model=viin.helpdesk.ticket&view_type=form

Ticket: https://viindoo.com/web#id=59883&cids=1&menu_id=89&action=1074&active_id=60&model=viin.helpdesk.ticket&view_type=form

Đoạn code cập nhật xml_id cho các sổ nhật ký đã tồn tại ở module account, nhưng logic tìm kiếm tìm không đúng, Dẫn tới việc sửa nhầm xml_id. 
Việc này dẫn tới hệ thống ghi đè thông tin sổ nhật ký theo dữ liệu từ template vào bản ghi bị gán sai xml_id, dẫn tới nhầm lẫn thông tin. 
Sổ nhật ký cần tạo mới thì không được tạo vì hệ thống hiểu là đã tồn tại, sổ nhật ký đã tồn tại thì bị sửa thông tin
 

Sau commit:
<img width="1920" height="719" alt="image" src="https://github.com/user-attachments/assets/413c858a-0ac2-4133-84b3-22500509bd65" />

